### PR TITLE
Fix runtime bug with custom cell class.

### DIFF
--- a/THSpringyCollectionView/Base.lproj/Main.storyboard
+++ b/THSpringyCollectionView/Base.lproj/Main.storyboard
@@ -27,7 +27,7 @@
                                     <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                 </collectionViewFlowLayout>
                                 <cells>
-                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="cellIdentifier" id="lJc-Ga-QSd" customClass="cellIdentifier">
+                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="cellIdentifier" id="lJc-Ga-QSd">
                                         <rect key="frame" x="0.0" y="0.0" width="320" height="50"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">


### PR DESCRIPTION
The custom class on `cellIdentifier` was what was responsible for the runtime error from the nib loading system. (Fixes https://github.com/tristanhimmelman/THSpringyCollectionView/issues/9)
